### PR TITLE
fix: wait for validator initialization

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,13 @@
 const { logger } = require('./utils')
+const server = require('./server')
 
-const server = require('./server')({
-  swaggerEnabled: true
-})
+async function start() {
+  const app = await server({
+    swaggerEnabled: true
+  })
 
-const port = process.env.PORT || 3000
+  const port = process.env.PORT || 3000
+  app.listen(port, () => logger.info(`Server listening on port ${port}!`))
+}
 
-server.listen(port, () => logger.info(`Server listening on port ${port}!`))
+start()

--- a/src/server.js
+++ b/src/server.js
@@ -13,7 +13,7 @@ const crypto = require('crypto')
 const defaultSettings = {
   swaggerEnabled: false
 }
-const appInitialization = (config = {}) => {
+const appInitialization = async (config = {}) => {
   const settings = { ...defaultSettings, ...config }
   logger.info(`Settings: ${JSON.stringify(settings)}`)
   const app = express()
@@ -36,7 +36,7 @@ const appInitialization = (config = {}) => {
   // Validation for API Endpoints
   if (settings.swaggerEnabled) {
     logger.info('Swagger enabled')
-    validator.init(app, {
+    await validator.init(app, {
       apiDocEndpoint: '/__/docs',
       fileUploader: false,
       validateRequests: true,


### PR DESCRIPTION
### Main changes

This PR solves the problem of the routes not being validated. The problem was that the validator is an `async` function that needs to be awaited. If we don't wait for the validator to be initialized, it won't work because the express routes will potentially be created before the validator is prepared.


### Evidence

![Captura de pantalla 2023-03-29 a las 16 49 06](https://user-images.githubusercontent.com/25435858/228577697-1ca65c71-1c2a-4f24-ac3b-a3d4c714c049.png)

### Context

🎫  Close #7 