### PR TITLE
Migrated routes from /v1/todos/* to /v1/todo/*

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Endpoints:
 
 - `GET /__/health` check health
 - `GET /__/docs` Swagger documentation for all the available endpoints
-- `GET /v1/todos` List all TODOS
-- `POST /v1/todos` Create a TODO
+- `GET /v1/todo` List all TODOS
+- `POST /v1/todo` Create a TODO
 - `GET /v1/todo/{id}` Get a specific TODO
 - `PUT /v1/todo/{id}` Update a specific TODO
 - `PATCH /v1/todo/{id}` PAtch a specific TODO property

--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -37,35 +37,35 @@ describe('GET /__/health', () => {
   })
 })
 
-describe('GET /v1/todos', () => {
+describe('GET /v1/todo', () => {
   it('should return all todos', async () => {
-    const res = await request(serverWithSwagger).get('/v1/todos')
+    const res = await request(serverWithSwagger).get('/v1/todo')
     expect(res.statusCode).toEqual(200)
     expect(res.body).toEqual(getAllTodos())
   })
 })
 
-describe('GET /v1/todos/:id', () => {
+describe('GET /v1/todo/:id', () => {
   it('should return a todo', async () => {
     const id = getAllTodos()[0].id
-    const res = await request(serverWithSwagger).get(`/v1/todos/${id}`)
+    const res = await request(serverWithSwagger).get(`/v1/todo/${id}`)
     expect(res.statusCode).toEqual(200)
     expect(res.body).toEqual(getTodoById(id))
   })
 
   it('should return 404 if todo not found', async () => {
     const res = await request(serverWithSwagger).get(
-      `/v1/todos/${fixtures.unusedId}`
+      `/v1/todo/${fixtures.unusedId}`
     )
     expect(res.statusCode).toEqual(404)
     expect(res.body).toEqual({ message: 'Todo not found' })
   })
 })
 
-describe('POST /v1/todos', () => {
+describe('POST /v1/todo', () => {
   it('should create a todo', async () => {
     const res = await request(serverWithSwagger)
-      .post('/v1/todos')
+      .post('/v1/todo')
       .send({
         title: 'New todo'
       })
@@ -76,25 +76,24 @@ describe('POST /v1/todos', () => {
   })
 })
 
-describe('PUT /v1/todos/:id', () => {
+describe('PUT /v1/todo/:id', () => {
   it('should update a todo', async () => {
     const id = getAllTodos()[0].id
     const res = await request(serverWithSwagger)
-      .put(`/v1/todos/${id}`)
+      .put(`/v1/todo/${id}`)
       .send({
-        id: fixtures.unusedId,
         title: 'Updated todo',
         completed: true
       })
     expect(res.statusCode).toEqual(200)
-    expect(res.body.id).toBe(fixtures.unusedId)
+    expect(res.body.id).toBe(id)
     expect(res.body.title).toBe('Updated todo')
     expect(res.body.completed).toBe(true)
   })
 
   it('should return 404 if todo not found', async () => {
     const res = await request(serverWithSwagger)
-      .put(`/v1/todos/${fixtures.unusedId}`)
+      .put(`/v1/todo/${fixtures.unusedId}`)
       .send({
         title: 'Updated todo',
         completed: true
@@ -104,12 +103,12 @@ describe('PUT /v1/todos/:id', () => {
   })
 })
 
-describe('PATCH /v1/todos/:id', () => {
+describe('PATCH /v1/todo/:id', () => {
   it('should update a todo', async () => {
     const { id, completed } = getAllTodos()[0]
 
     const res = await request(serverWithSwagger)
-      .patch(`/v1/todos/${id}`)
+      .patch(`/v1/todo/${id}`)
       .send({
         title: 'Updated todo'
       })
@@ -122,7 +121,7 @@ describe('PATCH /v1/todos/:id', () => {
 
   it('should return 404 if todo not found', async () => {
     const res = await request(serverWithSwagger)
-      .patch(`/v1/todos/${fixtures.unusedId}`)
+      .patch(`/v1/todo/${fixtures.unusedId}`)
       .send({
         title: 'Updated todo',
         completed: true
@@ -132,10 +131,10 @@ describe('PATCH /v1/todos/:id', () => {
   })
 })
 
-describe('DELETE /v1/todos/:id', () => {
+describe('DELETE /v1/todo/:id', () => {
   it('should delete a todo', async () => {
     const id = getAllTodos()[0].id
-    const res = await request(serverWithSwagger).delete(`/v1/todos/${id}`)
+    const res = await request(serverWithSwagger).delete(`/v1/todo/${id}`)
 
     expect(res.statusCode).toEqual(200)
     expect(res.body.id).toBe(id)
@@ -143,7 +142,7 @@ describe('DELETE /v1/todos/:id', () => {
 
   it('should return 404 if todo not found', async () => {
     const res = await request(serverWithSwagger).delete(
-      `/v1/todos/${fixtures.unusedId}`
+      `/v1/todo/${fixtures.unusedId}`
     )
     expect(res.statusCode).toEqual(404)
     expect(res.body).toEqual({ message: 'Todo not found' })

--- a/src/server.js
+++ b/src/server.js
@@ -53,17 +53,17 @@ const appInitialization = async (config = {}) => {
     res.json({ status: 'UP' })
   })
 
-  app.get('/v1/todos', (req, res) => {
+  app.get('/v1/todo', (req, res) => {
     logger.info('Getting all todos')
     res.json(getAllTodos())
   })
 
-  app.get('/v1/todos/:id', handleNotFoundTodoMiddleware, (req, res) => {
+  app.get('/v1/todo/:id', handleNotFoundTodoMiddleware, (req, res) => {
     logger.info(`Getting todo with id ${req.params.id}`)
     res.json(req.todo)
   })
 
-  app.post('/v1/todos', (req, res) => {
+  app.post('/v1/todo', (req, res) => {
     logger.info('Creating todo')
     res.json({
       title: req.body.title,
@@ -72,17 +72,17 @@ const appInitialization = async (config = {}) => {
     })
   })
 
-  app.put('/v1/todos/:id', handleNotFoundTodoMiddleware, (req, res) => {
+  app.put('/v1/todo/:id', handleNotFoundTodoMiddleware, (req, res) => {
     logger.info(`Updating todo with id ${req.params.id}`)
-    res.json(req.body)
+    res.json({ ...req.todo, ...req.body })
   })
 
-  app.delete('/v1/todos/:id', handleNotFoundTodoMiddleware, (req, res) => {
+  app.delete('/v1/todo/:id', handleNotFoundTodoMiddleware, (req, res) => {
     logger.info(`Deleting todo with id ${req.params.id}`)
     res.json(req.todo)
   })
 
-  app.patch('/v1/todos/:id', handleNotFoundTodoMiddleware, (req, res) => {
+  app.patch('/v1/todo/:id', handleNotFoundTodoMiddleware, (req, res) => {
     logger.info(`Updating todo with id ${req.params.id}`)
     res.json({ ...req.todo, ...req.body })
   })

--- a/src/syncapi.yaml
+++ b/src/syncapi.yaml
@@ -10,7 +10,7 @@ tags:
     description: Everything about todos
 
 paths:
-  /v1/todos:
+  /v1/todo:
     post:
       tags:
         - todo
@@ -76,7 +76,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Todo'
+              $ref: '#/components/schemas/TodoUpdate'
       responses:
         '200':
           description: Todo updated
@@ -221,12 +221,19 @@ paths:
                 $ref: '#/components/schemas/Error'
 components:
   schemas:
+    TodoUpdate:
+      type: object
+      properties:
+        title:
+          type: string
+        completed:
+          type: boolean
+      required:
+        - title
+        - completed
     TodoPatch:
       type: object
       properties:
-        id:
-          type: string
-          pattern: '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
         title:
           type: string
         completed:


### PR DESCRIPTION
### Main changes
- Updated documentation
- Updated tests
- Removed the option to replace the ID in any PUT/PATCH Request
- Updated Swagger specs

### Context

- Solved broken tests in #26 

### Changelog

- cfc95f2 chore: migrated routes from `/v1/todos/*` to `/v1/todo/*` by @UlisesGascon
